### PR TITLE
Fix pkg-config library name

### DIFF
--- a/config/discover.ml
+++ b/config/discover.ml
@@ -10,7 +10,7 @@ let () =
       match C.Pkg_config.get c with
       | None -> default
       | Some pc ->
-        match C.Pkg_config.query pc ~package:"mpg123" with
+        match C.Pkg_config.query pc ~package:"libmpg123" with
         | None -> default
         | Some deps -> deps
     in


### PR DESCRIPTION
This should fix issues on FreeBSD and other platforms or configurations.
Full log: https://travis-ci.org/github/ocaml/opam-repository/jobs/739401198