### PR TITLE
Update dune-project

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -22,8 +22,6 @@
  (depends
   (ocaml
    (>= 4.03))
-  (dune
-   (>= 2.0))
   dune-configurator
   conf-pkg-config
   (ctypes


### PR DESCRIPTION
The dune dependency is automatically added to the opam file with the correct lower bound, this line is not needed